### PR TITLE
Add support for Anthropic system prompt

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -1906,13 +1906,9 @@ Here is how to get those api-keys:
 			<key>config</key>
 			<dict>
 				<key>default</key>
-				<string>claude-3-5-sonnet-20240620</string>
+				<string>claude-3-opus-20240229</string>
 				<key>pairs</key>
 				<array>
-					<array>
-						<string>Claude 3.5 Sonnet</string>
-						<string>claude-3-5-sonnet-20240620</string>
-					</array>
 					<array>
 						<string>Claude 3.5 Sonnet</string>
 						<string>claude-3-5-sonnet-20240620</string>

--- a/info.plist
+++ b/info.plist
@@ -1009,7 +1009,7 @@ fi</string>
 				<key>inputtype</key>
 				<integer>1</integer>
 				<key>loadingtext</key>
-				<string>Querying ChatGPT API…</string>
+				<string>Querying LLM…</string>
 				<key>outputmode</key>
 				<integer>1</integer>
 				<key>scriptinput</key>

--- a/info.plist
+++ b/info.plist
@@ -1906,9 +1906,13 @@ Here is how to get those api-keys:
 			<key>config</key>
 			<dict>
 				<key>default</key>
-				<string>claude-3-opus-20240229</string>
+				<string>claude-3-5-sonnet-20240620</string>
 				<key>pairs</key>
 				<array>
+					<array>
+						<string>Claude 3.5 Sonnet</string>
+						<string>claude-3-5-sonnet-20240620</string>
+					</array>
 					<array>
 						<string>Claude 3.5 Sonnet</string>
 						<string>claude-3-5-sonnet-20240620</string>


### PR DESCRIPTION
# Proposed changes

- Following the [Anthropic API reference](https://docs.anthropic.com/en/api/messages), adjust the format of the messages to add support for system prompt.
- Use generic loading text - `LLM` instead of `ChatGPT API`
