### PR TITLE
Add Ollama and reformat settings UI

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -1754,10 +1754,14 @@ Here is how to get those api-keys:
 						<string>qwen</string>
 						<string>qwen</string>
 					</array>
+					<array>
+						<string>ollama</string>
+						<string>ollama</string>
+					</array>
 				</array>
 			</dict>
 			<key>description</key>
-			<string>select an LLM servcie provider</string>
+			<string>select an LLM service provider</string>
 			<key>label</key>
 			<string>Select Provider</string>
 			<key>type</key>
@@ -1778,95 +1782,13 @@ Here is how to get those api-keys:
 				<true/>
 			</dict>
 			<key>description</key>
-			<string></string>
+			<string>API Key</string>
 			<key>label</key>
-			<string>OpenAI API Key</string>
+			<string>OpenAI</string>
 			<key>type</key>
 			<string>textfield</string>
 			<key>variable</key>
 			<string>openai_api_key</string>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>default</key>
-				<string></string>
-				<key>placeholder</key>
-				<string></string>
-				<key>required</key>
-				<false/>
-				<key>trim</key>
-				<true/>
-			</dict>
-			<key>description</key>
-			<string></string>
-			<key>label</key>
-			<string>Anthropic Api Key</string>
-			<key>type</key>
-			<string>textfield</string>
-			<key>variable</key>
-			<string>anthropic_api_key</string>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>default</key>
-				<string></string>
-				<key>placeholder</key>
-				<string></string>
-				<key>required</key>
-				<false/>
-				<key>trim</key>
-				<true/>
-			</dict>
-			<key>description</key>
-			<string></string>
-			<key>label</key>
-			<string>Gemini Api Key</string>
-			<key>type</key>
-			<string>textfield</string>
-			<key>variable</key>
-			<string>gemini_api_key</string>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>default</key>
-				<string></string>
-				<key>placeholder</key>
-				<string></string>
-				<key>required</key>
-				<false/>
-				<key>trim</key>
-				<true/>
-			</dict>
-			<key>description</key>
-			<string></string>
-			<key>label</key>
-			<string>Qwen Api Key</string>
-			<key>type</key>
-			<string>textfield</string>
-			<key>variable</key>
-			<string>qwen_api_key</string>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>default</key>
-				<true/>
-				<key>required</key>
-				<false/>
-				<key>text</key>
-				<string>Save current chat when starting a new one</string>
-			</dict>
-			<key>description</key>
-			<string></string>
-			<key>label</key>
-			<string>Keep History</string>
-			<key>type</key>
-			<string>checkbox</string>
-			<key>variable</key>
-			<string>chat_history_save</string>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -1894,13 +1816,32 @@ Here is how to get those api-keys:
 				</array>
 			</dict>
 			<key>description</key>
-			<string></string>
-			<key>label</key>
-			<string>OpenAi Model</string>
+			<string>Model</string>
 			<key>type</key>
 			<string>popupbutton</string>
 			<key>variable</key>
 			<string>openai_model</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string></string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>API Key</string>
+			<key>label</key>
+			<string>Anthropic</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>anthropic_api_key</string>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -1928,13 +1869,32 @@ Here is how to get those api-keys:
 				</array>
 			</dict>
 			<key>description</key>
-			<string></string>
-			<key>label</key>
-			<string>Anthropic Model</string>
+			<string>Model</string>
 			<key>type</key>
 			<string>popupbutton</string>
 			<key>variable</key>
 			<string>anthropic_model</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string></string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>API Key</string>
+			<key>label</key>
+			<string>Gemini</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>gemini_api_key</string>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -1958,13 +1918,34 @@ Here is how to get those api-keys:
 				</array>
 			</dict>
 			<key>description</key>
-			<string></string>
+			<string>Model</string>
 			<key>label</key>
-			<string>Gemini Model</string>
+			<string></string>
 			<key>type</key>
 			<string>popupbutton</string>
 			<key>variable</key>
 			<string>gemini_model</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string></string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>API Key</string>
+			<key>label</key>
+			<string>Qwen</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>qwen_api_key</string>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -1988,13 +1969,74 @@ Here is how to get those api-keys:
 				</array>
 			</dict>
 			<key>description</key>
-			<string></string>
+			<string>Model</string>
 			<key>label</key>
-			<string>Qwen Model</string>
+			<string></string>
 			<key>type</key>
 			<string>popupbutton</string>
 			<key>variable</key>
 			<string>qwen_model</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string></string>
+				<key>placeholder</key>
+				<string>http://localhost:11434</string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>API Endpoint</string>
+			<key>label</key>
+			<string>Ollama</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>ollama_api_endpoint</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>llama3.1</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>model (ensure it is pulled)</string>
+			<key>label</key>
+			<string></string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>ollama_model</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<true/>
+				<key>required</key>
+				<false/>
+				<key>text</key>
+				<string>Save current chat when starting a new one</string>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>Keep History</string>
+			<key>type</key>
+			<string>checkbox</string>
+			<key>variable</key>
+			<string>chat_history_save</string>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -2034,7 +2076,7 @@ Here is how to get those api-keys:
 				<integer>3</integer>
 			</dict>
 			<key>description</key>
-			<string>Initial message to guide ChatGPT on the answers you expect.</string>
+			<string>Initial message to guide the LLM on the answers you expect.</string>
 			<key>label</key>
 			<string>System Prompt</string>
 			<key>type</key>

--- a/src/chat.py
+++ b/src/chat.py
@@ -6,6 +6,7 @@ from openai import OpenaiService
 from anthropic import AnthropicService
 from gemini import GeminiService
 from qwen import QwenService
+from ollama import OllamaService
 from helper import *
 from llm_service import LLMService
 
@@ -40,6 +41,9 @@ def run(argv):
     qwen_api_key = env_var("qwen_api_key")
     qwen_model = env_var("qwen_model")
 
+    ollama_api_endpoint = env_var("ollama_api_endpoint")
+    ollama_model = env_var("ollama_model")
+
     llm_service = None
     if selected_llm_service == "openai":
         llm_service = OpenaiService(openai_api_endpoint, openai_api_key, openai_model, http_proxy, socks5_proxy)
@@ -49,6 +53,8 @@ def run(argv):
         llm_service = GeminiService(gemini_api_endpoint, gemini_api_key, gemini_model, http_proxy, socks5_proxy)
     elif selected_llm_service == "qwen":
         llm_service = QwenService(qwen_api_endpoint, qwen_api_key, qwen_model, http_proxy, socks5_proxy)
+    elif selected_llm_service == "ollama":
+        llm_service = OllamaService(ollama_api_endpoint, ollama_model, http_proxy, socks5_proxy)
 
     if streaming_now:
         return llm_service.read_stream(stream_file, chat_file, pid_stream_file, stream_marker)

--- a/src/ollama.py
+++ b/src/ollama.py
@@ -1,0 +1,44 @@
+import json
+from llm_service import LLMService
+
+class OllamaService(LLMService):
+    def __init__(self, api_endpoint, model, http_proxy, socks5_proxy):
+        super().__init__(api_endpoint, "", model, http_proxy, socks5_proxy)
+
+    def construct_curl_command(self, max_tokens, messages, stream_file):
+        data = {
+            "model": self.model,
+            "messages": messages,
+            "stream": True,
+            "options": {
+                "num_predict": max_tokens
+            },
+        }
+
+        return [
+            "curl",
+            f"{self.api_endpoint}/api/chat",
+            "--speed-limit", "0", "--speed-time", "5",  # Abort stalled connection after a few seconds
+            "--silent", "--no-buffer",
+            "--header", "Content-Type: application/json",
+            "--data", json.dumps(data),
+            "--output", stream_file
+        ] + self.proxy_option
+
+    def parse_stream_response(self, stream_string):
+        response_text = ""
+        error_message = ""
+        has_stopped = False
+
+        for line in stream_string.split("\n"):
+            if line.strip():
+                try:
+                    chunk = json.loads(line)
+                    if 'message' in chunk:
+                        response_text += chunk['message']['content']
+                    if 'done' in chunk and chunk['done']:
+                        has_stopped = True
+                except json.JSONDecodeError:
+                    error_message = "Error parsing JSON response"
+
+        return response_text, error_message, has_stopped


### PR DESCRIPTION
This PR adds the capability of talking to Ollama models (https://ollama.com/).

- Add necessary configuration.
- Add `OllamaService` class.
- Reformat the settings: They were cluttered, so I grouped the configurations by provider.

