### PR TITLE
update Google Gemini models

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -1900,7 +1900,7 @@ Here is how to get those api-keys:
 			<key>config</key>
 			<dict>
 				<key>default</key>
-				<string>gemini-1.5-pro</string>
+				<string>gemini-2.0-flash</string>
 				<key>pairs</key>
 				<array>
 					<array>
@@ -1908,12 +1908,12 @@ Here is how to get those api-keys:
 						<string>gemini-1.5-pro</string>
 					</array>
 					<array>
-						<string>Gemini 1.5 Flash</string>
-						<string>gemini-1.5-flash</string>
+						<string>Gemini 2.0 Flash</string>
+						<string>gemini-2.0-flash</string>
 					</array>
 					<array>
-						<string>Gemini 1.0 Pro</string>
-						<string>gemini-1.0-pro</string>
+						<string>Gemini 2.0 Flash Lite</string>
+						<string>gemini-2.0-flash-lite</string>
 					</array>
 				</array>
 			</dict>


### PR DESCRIPTION
replaces Google Gemini Flash 1.0 and 1.5 with Flash 2.0 and Flash Lite 2.0