### PR TITLE
Fix an issue where the `content` field in `chat.json` can be `null`

### DIFF
--- a/src/llm_service.py
+++ b/src/llm_service.py
@@ -105,7 +105,7 @@ class LLMService(ABC):
                 "behaviour": {"response": "replacelast"}
             })
 
-        append_chat(chat_file, {"role": "assistant", "content": response_text if response_text else error_message})
+        append_chat(chat_file, {"role": "assistant", "content": response_text or error_message or ""})
         delete_file(stream_file)
         delete_file(pid_stream_file)
 

--- a/src/llm_service.py
+++ b/src/llm_service.py
@@ -87,7 +87,7 @@ class LLMService(ABC):
             delete_file(pid_stream_file)
             return json.dumps({
                 "response": f"{response_text} [Connection Stalled]",
-                "footer": "You can ask ChatGPT to continue the answer",
+                "footer": "You can ask the assistant to continue the answer",
                 "behaviour": {"response": "replacelast", "scroll": "end"}
             })
 


### PR DESCRIPTION
This seems to happen occasionally (didn't dig into exactly why this happens) since each concrete implementation of `LLMService.parse_stream_response()` allows `error_message` to be returned as `None`. This leads to an error when parsing `chat.json`:
```
[23:04:29.709] ERROR: ChatHub[Text View] Code 1: Traceback (most recent call last):
  File "<root-path>/src/chat.py", line 93, in <module>
    output = run(sys.argv[1:])
  File "<root-path>/src/chat.py", line 74, in run
    "response": markdown_chat(previous_chat, False),
  File "<root-path>/src/helper.py", line 57, in markdown_chat
    result += assistant_signature() + current["content"] + "\n\n"
TypeError: can only concatenate str (not "NoneType") to str
```
Although this can be resolved by starting a new chat, there is no prompt on the UI indicating how to resolve this issue. This change thus ensure that the `content` field is never `null`.

This change also includes a minor fix to the footer text when connection is stalled: replaced the default "ChatGPT" with a more generic text.